### PR TITLE
fix: 修复mac构建win平台产物报错问题

### DIFF
--- a/src/inner_log.h
+++ b/src/inner_log.h
@@ -38,17 +38,17 @@ void aos_log_set_level(aos_log_level_e level);
 #ifdef WIN32
 #define __FL_NME__ (strchr(__FILE__, '\\') ? strrchr(__FILE__, '\\') + 1 : __FILE__)
 #define aos_fatal_log(format, ...) if(aos_log_level>=AOS_LOG_FATAL) \
-        aos_log_format(AOS_LOG_FATAL, __FL_NME__, __LINE__, __FUNCTION__, format, __VA_ARGS__)
+        aos_log_format(AOS_LOG_FATAL, __FL_NME__, __LINE__, __FUNCTION__, format, ##__VA_ARGS__)
 #define aos_error_log(format, ...) if(aos_log_level>=AOS_LOG_ERROR) \
-        aos_log_format(AOS_LOG_ERROR, __FL_NME__, __LINE__, __FUNCTION__, format, __VA_ARGS__)
+        aos_log_format(AOS_LOG_ERROR, __FL_NME__, __LINE__, __FUNCTION__, format, ##__VA_ARGS__)
 #define aos_warn_log(format, ...) if(aos_log_level>=AOS_LOG_WARN)   \
-        aos_log_format(AOS_LOG_WARN, __FL_NME__, __LINE__, __FUNCTION__, format, __VA_ARGS__)
+        aos_log_format(AOS_LOG_WARN, __FL_NME__, __LINE__, __FUNCTION__, format, ##__VA_ARGS__)
 #define aos_info_log(format, ...) if(aos_log_level>=AOS_LOG_INFO)   \
-        aos_log_format(AOS_LOG_INFO, __FL_NME__, __LINE__, __FUNCTION__, format, __VA_ARGS__)
+        aos_log_format(AOS_LOG_INFO, __FL_NME__, __LINE__, __FUNCTION__, format, ##__VA_ARGS__)
 #define aos_debug_log(format, ...) if(aos_log_level>=AOS_LOG_DEBUG) \
-        aos_log_format(AOS_LOG_DEBUG, __FL_NME__, __LINE__, __FUNCTION__, format, __VA_ARGS__)
+        aos_log_format(AOS_LOG_DEBUG, __FL_NME__, __LINE__, __FUNCTION__, format, ##__VA_ARGS__)
 #define aos_trace_log(format, ...) if(aos_log_level>=AOS_LOG_TRACE) \
-        aos_log_format(AOS_LOG_TRACE, __FL_NME__, __LINE__, __FUNCTION__, format, __VA_ARGS__)
+        aos_log_format(AOS_LOG_TRACE, __FL_NME__, __LINE__, __FUNCTION__, format, ##__VA_ARGS__)
 #else
 #define __FL_NME__ (strchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
 #define aos_fatal_log(format, args...) if(aos_log_level>=AOS_LOG_FATAL) \

--- a/src/log_api.c
+++ b/src/log_api.c
@@ -124,7 +124,11 @@ void get_now_time_str(char * buffer, int bufLen, int timeOffset)
     {
         rawtime += timeOffset;
     }
+#ifdef WIN32
+    gmtime_s(&rawtime, &timeinfo);
+#else
     gmtime_r(&rawtime, &timeinfo);
+#endif
     sls_rfc822_date(buffer, &timeinfo);
 }
 

--- a/src/log_define.h
+++ b/src/log_define.h
@@ -3,7 +3,7 @@
 
 
 #ifdef WIN32
-#define LOG_EXPORT _declspec(dllexport)
+#define LOG_EXPORT
 #else
 #define LOG_EXPORT
 #endif

--- a/src/log_producer_sender.h
+++ b/src/log_producer_sender.h
@@ -9,6 +9,7 @@
 #include "log_define.h"
 #include "log_producer_config.h"
 #include "log_builder.h"
+#include <stdint.h>
 LOG_CPP_START
 
 #define LOG_PRODUCER_SEND_MAGIC_NUM 0x1B35487A

--- a/src/log_ring_file.c
+++ b/src/log_ring_file.c
@@ -33,7 +33,9 @@ static int log_ring_file_open_fd(log_ring_file *file, uint64_t offset, int32_t f
     int openFlag = O_RDWR|O_CREAT;
     if (file->syncWrite)
     {
+#ifdef O_SYNC
         openFlag |= O_SYNC;
+#endif
     }
     file->nowFD = open(filePath, openFlag, 0644);
     if (file->nowFD < 0)
@@ -216,7 +218,11 @@ int log_ring_file_flush(log_ring_file *file)
 {
     if (file->nowFD > 0)
     {
+#ifdef WIN32
+        return _commit(file->nowFD);
+#else
         return fsync(file->nowFD);
+#endif
     }
     return -1;
 }

--- a/src/log_ring_file.h
+++ b/src/log_ring_file.h
@@ -6,6 +6,7 @@
 #define LOG_C_SDK_LOG_RING_FILE_H
 
 #include "log_inner_include.h"
+#include <stdint.h>
 
 typedef struct _log_ring_file
 {


### PR DESCRIPTION
1. 修复`aos_debug_log`的编译问题
2. 修复win下没有`gmtime_r`的问题，使用`gmtime_s`替代
3. 修复win下`LOG_EXPORT`的问题
4. 修复部分c文件漏掉`include stdint`而导致`uint64_t`等找不到的问题
5. 修复win下没有`fsync`方法的问题，使用`_commit `替代